### PR TITLE
Fix: Ensure Unique MCQ Upload

### DIFF
--- a/src/alembic_migrations/versions/50801e3035e7_add_unique_constraint_to_question_.py
+++ b/src/alembic_migrations/versions/50801e3035e7_add_unique_constraint_to_question_.py
@@ -1,0 +1,28 @@
+"""Add unique constraint to question column in mcqs table
+
+Revision ID: 50801e3035e7
+Revises: 96cd159c6b79
+Create Date: 2025-01-16 09:34:29.417782
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "50801e3035e7"
+down_revision: Union[str, None] = "96cd159c6b79"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Adding a unique constraint to the question column
+    op.create_unique_constraint("uq_mcqs_question", "mcqs", ["question"])
+
+
+def downgrade() -> None:
+    # Dropping the unique constraint in case of a rollback
+    op.drop_constraint("uq_mcqs_question", "mcqs", type_="unique")

--- a/src/app/repositories/mcq_repository.py
+++ b/src/app/repositories/mcq_repository.py
@@ -35,17 +35,22 @@ class McqRepository(BaseRepository[MCQ]):
     def get_all(
         self,
         type_: Optional[str] = None,
+        question: Optional[str] = None,
     ) -> List[MCQ]:
         """
         Retrieve all mcq from the database.
 
         Returns: List[MCQ]
             A list of MCQ objects.
+            unit_of_work.session.query(MCQ).filter_by(question=row.get("question")).first()
         """
         query = self.session.query(MCQ)
 
         if type_:
             query = query.filter(MCQ.type == type_)
+
+        if question:
+            query = query.filter(MCQ.question == question)
 
         return query.all()
 

--- a/src/app/routes/v1/admin_routers.py
+++ b/src/app/routes/v1/admin_routers.py
@@ -109,10 +109,15 @@ def bulk_upload_mcqs(
         dict: Response message with the count of MCQs successfully added.
     """
     unit_of_work = McqUnitOfWork()
-    mcq_count = mcq_services.bulk_add_mcqs(
+    added_count, skipped_count = mcq_services.bulk_add_mcqs(
         unit_of_work=unit_of_work, file=file, current_user=current_user
     )
-    return {"message": f"{mcq_count} MCQs successfully added."}
+    if skipped_count:
+        return {
+            "message": f"{added_count} unique MCQs added and {skipped_count} duplicate MCQs skipped."
+        }
+    else:
+        return {"message": f"{added_count} unique MCQs added."}
 
 
 @router.post("/mcq", status_code=201)


### PR DESCRIPTION
1.  Added alembic revision to add a unique constraint to the question column in the mcqs table to prevent duplicate entries.
3. Updated the bulk_add_mcqs function to skip duplicate questions and add only unique ones.